### PR TITLE
Use correct docker image for convex-backend

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       start_period: 5s
 
   ourfiles-dashboard:
-    image: ghcr.io/get-convex/self-hosted-dashboard:latest
+    image: ghcr.io/get-convex/convex-dashboard:latest
     restart: always
     ports:
       - "${DASHBOARD_PORT:-6791}:6791"

--- a/self-hosted/Dockerfile
+++ b/self-hosted/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/get-convex/self-hosted-backend:latest
+FROM ghcr.io/get-convex/convex-backend:latest
 
 WORKDIR /convex
 


### PR DESCRIPTION
Convex renamed the image from `self-hosted-backend` to `convex-backend` so this should be updated so folks using this get the up-to-date version.